### PR TITLE
Add testing on Ruby 2.4.1

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 - [ ] RuboCop passes
 
-- [ ] Existing tests pass 
+- [ ] Existing tests pass
 
 #### New Plugins
 
@@ -24,5 +24,5 @@
 
 #### Purpose
 
-#### Known Compatablity Issues
+#### Known Compatability Issues
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ rvm:
 - 2.1
 - 2.2
 - 2.3.0
+- 2.4.1
 notifications:
   email:
     recipients:
@@ -30,4 +31,5 @@ deploy:
     rvm: 2.1
     rvm: 2.2
     rvm: 2.3.0
+    rvm: 2.4.1
     repo: sensu-plugins/sensu-plugins-freeradius

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 - Support for Ruby 2.3.0
 - Testing on Ruby 2.4.1
 
+### Breaking Changes
+- Updated sensu-plugin dependency to 2.0
+
 ### Removed
 - Support for Ruby 1.9.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This CHANGELOG follows the format listed at [Keep A Changelog](http://keepachang
 
 ### Added
 - Support for Ruby 2.3.0
+- Testing on Ruby 2.4.1
 
 ### Removed
 - Support for Ruby 1.9.3

--- a/sensu-plugins-freeradius.gemspec
+++ b/sensu-plugins-freeradius.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.test_files             = s.files.grep(%r{^(test|spec|features)/})
   s.version                = SensuPluginsFreeradius::Version::VER_STRING
 
-  s.add_runtime_dependency 'sensu-plugin', '~> 1.2'
+  s.add_runtime_dependency 'sensu-plugin', '~> 2.0'
 
   s.add_development_dependency 'bundler',                   '~> 1.7'
   s.add_development_dependency 'codeclimate-test-reporter', '~> 0.4'


### PR DESCRIPTION
## Pull Request Checklist

RE https://github.com/sensu-plugins/sensu-plugins-feature-requests/issues/27

#### General

- [x] Update Changelog following the conventions laid out on [Keep A Changelog](http://keepachangelog.com/)

- [x] RuboCop passes

- [x] Existing tests pass 

#### Purpose

Add testing on Ruby 2.4.1

#### Known Compatablity Issues

This change increases the required version of sensu-plugin to 2.0. This will most definitely cause issues for a lot of users.
